### PR TITLE
Update config.json

### DIFF
--- a/rtl4332mqtt/config.json
+++ b/rtl4332mqtt/config.json
@@ -9,6 +9,7 @@
   "map": ["config:rw", "ssl"],
   "usb": true,
   "host_network": "False",
+  "init": "false"
   "arch": [
     "aarch64",
     "amd64",

--- a/rtl4332mqtt/config.json
+++ b/rtl4332mqtt/config.json
@@ -9,7 +9,7 @@
   "map": ["config:rw", "ssl"],
   "usb": true,
   "host_network": "False",
-  "init": "false"
+  "init": "false",
   "arch": [
     "aarch64",
     "amd64",


### PR DESCRIPTION
added 
init: false
to fix 's6-overlay-suexec: fatal: can only run as pid 1' error